### PR TITLE
update for rook wps

### DIFF
--- a/notebooks/rooki-demo.ipynb
+++ b/notebooks/rooki-demo.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "# The same as using birdy\n",
     "#from birdy import WPSClient\n",
-    "#url = 'https://bovec.dkrz.de/ows/proxy/roocs'\n",
+    "#url = 'https://bovec.dkrz.de/ows/proxy/rook'\n",
     "#url = 'http://localhost:5000/wps'\n",
     "#rooki = WPSClient(url, verify=False)"
    ]
@@ -45,10 +45,10 @@
      "data": {
       "text/plain": [
        "\u001b[0;31mType:\u001b[0m            WPSClient\n",
-       "\u001b[0;31mString form:\u001b[0m     <birdy.client.base.WPSClient object at 0x10a16af70>\n",
+       "\u001b[0;31mString form:\u001b[0m     <birdy.client.base.WPSClient object at 0x10bb4ed00>\n",
        "\u001b[0;31mFile:\u001b[0m            ~/.conda/envs/rooki/lib/python3.8/site-packages/birdy/client/base.py\n",
        "\u001b[0;31mDocstring:\u001b[0m      \n",
-       "A demostrator for a WPS service for roocs.\n",
+       "A WPS service for roocs.\n",
        "\n",
        "Processes\n",
        "---------\n",
@@ -172,7 +172,7 @@
      "data": {
       "text/plain": [
        "subsetResponse(\n",
-       "    output='https://bovec.dkrz.de/download/outputs/roocswps/26797ff0-6a08-11ea-94ce-109836a7cf3a/output.nc'\n",
+       "    output='https://bovec.dkrz.de/download/outputs/rook/885c1130-7f2d-11ea-be3b-109836a7cf3a/output.nc'\n",
        ")"
       ]
      },
@@ -249,7 +249,7 @@
     {
      "data": {
       "text/plain": [
-       "\u001b[0;31mSignature:\u001b[0m \u001b[0mrooki\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0morchestrate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mworkflow\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'tree'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mSignature:\u001b[0m \u001b[0mrooki\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0morchestrate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mworkflow\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
        "\u001b[0;31mDocstring:\u001b[0m\n",
        "Run a workflow\n",
        "\n",
@@ -257,8 +257,6 @@
        "----------\n",
        "workflow : ComplexData:mimetype:`application/json`\n",
        "    Workflow\n",
-       "mode : {'tree', 'simple'}string\n",
-       "    Mode\n",
        "\n",
        "Returns\n",
        "-------\n",
@@ -329,7 +327,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "resp_wf = rooki.orchestrate(workflow=wf_simple_json, mode='simple')"
+    "resp_wf = rooki.orchestrate(workflow=wf_simple_json)"
    ]
   },
   {
@@ -341,7 +339,7 @@
      "data": {
       "text/plain": [
        "orchestrateResponse(\n",
-       "    output='https://bovec.dkrz.de/download/outputs/roocswps/314957de-6a08-11ea-94ce-109836a7cf3a/output.nc'\n",
+       "    output='https://bovec.dkrz.de/download/outputs/rook/92e0760a-7f2d-11ea-9038-109836a7cf3a/output.nc'\n",
        ")"
       ]
      },
@@ -427,7 +425,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "resp_wf = rooki.orchestrate(workflow=wf_tree_json, mode='tree')"
+    "resp_wf = rooki.orchestrate(workflow=wf_tree_json)"
    ]
   },
   {
@@ -439,7 +437,7 @@
      "data": {
       "text/plain": [
        "orchestrateResponse(\n",
-       "    output='https://bovec.dkrz.de/download/outputs/roocswps/382a84a6-6a08-11ea-94ce-109836a7cf3a/output.nc'\n",
+       "    output='https://bovec.dkrz.de/download/outputs/rook/99450aa6-7f2d-11ea-9038-109836a7cf3a/output.nc'\n",
        ")"
       ]
      },
@@ -526,7 +524,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "resp_wf = rooki.orchestrate(workflow=wf_tree_json, mode='tree')"
+    "resp_wf = rooki.orchestrate(workflow=wf_tree_json)"
    ]
   },
   {
@@ -538,7 +536,7 @@
      "data": {
       "text/plain": [
        "orchestrateResponse(\n",
-       "    output='https://bovec.dkrz.de/download/outputs/roocswps/409b1a74-6a08-11ea-94ce-109836a7cf3a/output.nc'\n",
+       "    output='https://bovec.dkrz.de/download/outputs/rook/9d753c7c-7f2d-11ea-9038-109836a7cf3a/output.nc'\n",
        ")"
       ]
      },

--- a/rooki/default.cfg
+++ b/rooki/default.cfg
@@ -2,4 +2,4 @@
 url = http://localhost:5000/wps
 
 [service]
-url = https://bovec.dkrz.de/ows/proxy/roocs
+url = https://bovec.dkrz.de/ows/proxy/rook


### PR DESCRIPTION
This PR updates the notebook for the rook wps:
https://bovec.dkrz.de/ows/proxy/rook?Service=WPS&Request=GetCapabilities&Version=1.0.0