### PR TITLE
fix binder config

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,5 +1,3 @@
 set -e
 
 python setup.py install
-
-export ROOK_URL="https://bovec.dkrz.de/ows/proxy/rook"

--- a/binder/start
+++ b/binder/start
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export ROOK_URL="https://bovec.dkrz.de/ows/proxy/rook"
+
+exec "$@"

--- a/rooki/config.py
+++ b/rooki/config.py
@@ -50,6 +50,10 @@ def load_configuration(cfgfiles=None):
     LOGGER.info('loading configuration')
     CONFIG = configparser.ConfigParser(os.environ)
 
+    LOGGER.debug('setting default values')
+    CONFIG.add_section('service')
+    CONFIG.set('service', 'url', 'http://localhost:5000/wps')
+
     config_files = _get_default_config_files_location()
     if cfgfiles:
         config_files.extend(cfgfiles)


### PR DESCRIPTION
This PR use the `start` script to set the `ROOK_URL` for binder.