### PR TITLE
Fix readme binder

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A client for roocs climate data operations service.
 You can try Rooki online using Binder (just click on the binder link below),
 or view the notebooks on NBViewer.
 
-[![Binder Launcher](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/roocs/rook.git/master?filepath=notebooks)
+[![Binder Launcher](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/roocs/rooki.git/master?filepath=notebooks)
 [![NBViewer](https://raw.githubusercontent.com/jupyter/design/master/logos/Badges/nbviewer_badge.svg)](https://nbviewer.jupyter.org/github/roocs/rooki/tree/master/notebooks/)
 
 

--- a/notebooks/demo/demo-monitoring-rook-wps.ipynb
+++ b/notebooks/demo/demo-monitoring-rook-wps.ipynb
@@ -32,7 +32,9 @@
     "\n",
     "Tests can be run via a cron-job. For example on Travis on a daily basis:\n",
     "\n",
-    "https://travis-ci.com/github/roocs/rooki/builds\n"
+    "https://travis-ci.com/github/roocs/rooki/builds\n",
+    "\n",
+    "[![Build Status](https://travis-ci.com/roocs/rooki.svg?branch=master)](https://travis-ci.com/roocs/rooki)\n"
    ]
   }
  ],


### PR DESCRIPTION
This PR fixes the binder link in Readme and adds a travis badge to the monitor notebook.