### PR TITLE
Use pymetalink from pypi

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -8,8 +8,8 @@ Install from Anaconda
 
 * TODO
 
-Install from Source
--------------------
+Install from PyPi
+-----------------
 
 Create a conda environment with birdy and install with pip:
 
@@ -17,7 +17,7 @@ Create a conda environment with birdy and install with pip:
 
   $ conda create -n rooki -c conda-forge python=3.8 birdy
   $ conda activate rooki
-  $ pip install git+https://github.com/roocs/rooki@master#egg=rooki
+  $ pip install rooki
 
 
 Install from GitHub

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Click>=6.0
 birdhouse-birdy>=0.6.9
 beautifulsoup4>=4.9.1
+pymetalink>=6.2

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
     },
     install_requires=[
         requirements,
-        "pymetalink @ git+https://github.com/metalink-dev/pymetalink.git",
+        # "pymetalink @ git+https://github.com/metalink-dev/pymetalink.git",
     ],
     long_description=_long_description,
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
This PR adds the `pymetalink` package from pypi to the requirements. This will fix #34.