### PR TITLE
allow python 3.6 and above

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,34 @@ matrix:
   fast_finish: true
   include:
     - os: linux
+      name: "Linux (Python3.6)"
+      python: "3.6"
+      addons:
+          apt:
+            packages:
+              - pandoc
+            update: true
+      env:
+        - CONDA_FN="Miniconda3-latest-Linux-x86_64.sh"
+        - PEP8=false
+        - BLACK=false
+        - DOCS=false
+        - PYTHON_DESIRED=3.6
+    - os: linux
+      name: "Linux (Python3.7 + docs)"
+      python: "3.7"
+      addons:
+          apt:
+            packages:
+              - pandoc
+            update: true
+      env:
+        - CONDA_FN="Miniconda3-latest-Linux-x86_64.sh"
+        - PEP8=false
+        - BLACK=false
+        - DOCS=true
+        - PYTHON_DESIRED=3.7
+    - os: linux
       name: "Linux (Python3.8 + pep8)"
       python: "3.8"
       addons:
@@ -28,6 +56,7 @@ matrix:
         - CONDA_FN="Miniconda3-latest-Linux-x86_64.sh"
         - PEP8=true
         - BLACK=true
+        - DOCS=false
         - PYTHON_DESIRED=3.8
 
 sudo: false
@@ -46,6 +75,7 @@ before_install:
 install:
   # Update now the env with our environment
   - conda env update -f environment.yml
+  - if [[ $DOCS == true ]]; then conda env update -f docs/environment.yml; fi
   - source activate rooki
   # Packages for testing
   - pip install pytest nbval flake8 black
@@ -56,3 +86,4 @@ script:
   - make test-nb
   - if [[ $PEP8 == true ]]; then flake8 rooki tests; fi
   - if [[ $BLACK == true ]]; then black --check --target-version py38 rooki tests; fi
+  - if [[ $DOCS == true ]]; then make -C docs html; fi

--- a/setup.py
+++ b/setup.py
@@ -53,9 +53,9 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Security",
         "Topic :: Internet",
         "Topic :: Scientific/Engineering",
@@ -67,7 +67,7 @@ setup(
     license=__license__,
     # This qualifier can be used to selectively exclude Python versions -
     # in this case early Python 2 and 3 releases
-    python_requires=">=3.7.0",
+    python_requires=">=3.6.0",
     entry_points={
         "console_scripts": [
             "rooki=rooki.cli:main",


### PR DESCRIPTION
Changes by this PR:
* require python >= 3.6
* run tests on several python versions >= 3.6 on travis
* run doc build test on travis
