### PR TITLE
configure metalink download folder

### DIFF
--- a/notebooks/demo/demo-rooki-advanced.ipynb
+++ b/notebooks/demo/demo-rooki-advanced.ipynb
@@ -22,6 +22,7 @@
    "source": [
     "import os\n",
     "os.environ['ROOK_URL'] = 'http://cp4cds-cn1.dkrz.de/wps'\n",
+    "# os.environ['ROOK_URL'] = 'http://localhost:5000/wps'\n",
     "# mode: sync or async\n",
     "# os.environ['ROOK_MODE'] = 'async'"
    ]
@@ -96,6 +97,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "files = resp.download()"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -109,8 +119,8 @@
    "outputs": [],
    "source": [
     "from rooki.client import Rooki\n",
-    "#url='http://cp4cds-cn1.dkrz.de/wps'\n",
-    "url='http://localhost:5000/wps'\n",
+    "url='http://cp4cds-cn1.dkrz.de/wps'\n",
+    "# url='http://localhost:5000/wps'\n",
     "\n",
     "rooki = Rooki(url, mode='async')\n",
     "rooki.url"

--- a/notebooks/demo/demo-rooki-advanced.ipynb
+++ b/notebooks/demo/demo-rooki-advanced.ipynb
@@ -34,7 +34,7 @@
    "outputs": [],
    "source": [
     "# change default download folder\n",
-    "os.environ['ROOKI_OUTPUT_DIR'] = '/tmp'"
+    "os.environ['ROOKI_OUTPUT_DIR'] = '/tmp/rooki'"
    ]
   },
   {
@@ -133,7 +133,7 @@
     "url='http://cp4cds-cn1.dkrz.de/wps'\n",
     "# url='http://localhost:5000/wps'\n",
     "\n",
-    "rooki = Rooki(url, mode='async', output_dir='/tmp')\n",
+    "rooki = Rooki(url, mode='async', output_dir='/tmp/rooki')\n",
     "rooki.url"
    ]
   },

--- a/notebooks/demo/demo-rooki-advanced.ipynb
+++ b/notebooks/demo/demo-rooki-advanced.ipynb
@@ -121,8 +121,10 @@
     "from rooki.client import Rooki\n",
     "url='http://cp4cds-cn1.dkrz.de/wps'\n",
     "# url='http://localhost:5000/wps'\n",
+    "output_dir = None\n",
+    "# output_dir = '/tmp/'\n",
     "\n",
-    "rooki = Rooki(url, mode='async')\n",
+    "rooki = Rooki(url, mode='async', output_dir=output_dir)\n",
     "rooki.url"
    ]
   },

--- a/notebooks/demo/demo-rooki-advanced.ipynb
+++ b/notebooks/demo/demo-rooki-advanced.ipynb
@@ -108,19 +108,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from rooki.client import Rooki"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "url='http://cp4cds-cn1.dkrz.de/wps'\n",
-    "mode=os.environ.get('ROOK_MODE', 'async')\n",
+    "from rooki.client import Rooki\n",
+    "#url='http://cp4cds-cn1.dkrz.de/wps'\n",
+    "url='http://localhost:5000/wps'\n",
     "\n",
-    "rooki = Rooki(url, mode=mode)\n",
+    "rooki = Rooki(url, mode='async')\n",
     "rooki.url"
    ]
   },
@@ -130,17 +122,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "collection = 'c3s-cmip5.output1.ICHEC.EC-EARTH.historical.day.atmos.day.r1i1p1.tas.latest'\n",
-    "time = '1850-01-01/2008-12-30'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "resp = rooki.subset(collection, time=time)\n",
+    "resp = rooki.subset(\n",
+    "    collection='c3s-cmip5.output1.ICHEC.EC-EARTH.historical.day.atmos.day.r1i1p1.tas.latest', \n",
+    "    time='1850-01-01/2008-12-30')\n",
     "resp.ok"
    ]
   },
@@ -210,7 +194,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/notebooks/demo/demo-rooki-advanced.ipynb
+++ b/notebooks/demo/demo-rooki-advanced.ipynb
@@ -4,14 +4,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# More things with Rooki"
+    "# Advanced Rooki Usage"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Use enviroment `ROOK_URL` to change rook wps"
+    "## Use enviroment to change rooki config"
    ]
   },
   {
@@ -33,6 +33,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# change default download folder\n",
+    "os.environ['ROOKI_OUTPUT_DIR'] = '/tmp'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# HINT: restart to re-init rooki!\n",
     "from rooki import rooki\n",
     "rooki.url"
@@ -44,8 +54,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "collection = 'c3s-cmip5.output1.ICHEC.EC-EARTH.historical.day.atmos.day.r1i1p1.tas.latest'\n",
-    "time = '1880-01-01/1900-12-30'"
+    "rooki.output_dir"
    ]
   },
   {
@@ -54,7 +63,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "resp = rooki.subset(collection, time=time)\n",
+    "resp = rooki.subset(\n",
+    "    collection='c3s-cmip5.output1.ICHEC.EC-EARTH.historical.day.atmos.day.r1i1p1.tas.latest', \n",
+    "    time='1880-01-01/1900-12-30')\n",
     "resp.ok"
    ]
   },
@@ -121,10 +132,8 @@
     "from rooki.client import Rooki\n",
     "url='http://cp4cds-cn1.dkrz.de/wps'\n",
     "# url='http://localhost:5000/wps'\n",
-    "output_dir = None\n",
-    "# output_dir = '/tmp/'\n",
     "\n",
-    "rooki = Rooki(url, mode='async', output_dir=output_dir)\n",
+    "rooki = Rooki(url, mode='async', output_dir='/tmp')\n",
     "rooki.url"
    ]
   },

--- a/rooki/client.py
+++ b/rooki/client.py
@@ -8,13 +8,14 @@ import logging
 
 
 class Rooki(WPSClient):
-    def __init__(self, url=None, mode=None, verify=None):
+    def __init__(self, url=None, mode=None, verify=None, output_dir=None):
         self._url = url or config.get_config_value("service", "url")
         self._mode = mode or config.get_config_value("service", "mode")
         if verify is None:
             self._verify = config.get_config_value("service", "ssl_verify")
         else:
             self._verify = verify
+        self.output_dir = output_dir
         progress = self.mode == ASYNC
         super(Rooki, self).__init__(self._url, verify=self._verify, progress=progress)
         self._notebook = False
@@ -35,7 +36,7 @@ class Rooki(WPSClient):
 
     def _execute(self, pid, **kwargs):
         resp = super(Rooki, self)._execute(pid, **kwargs)
-        return Result(resp)
+        return Result(resp, output_dir=self.output_dir)
 
 
 rooki = Rooki()

--- a/rooki/client.py
+++ b/rooki/client.py
@@ -1,3 +1,5 @@
+import os
+
 from birdy import WPSClient
 from owslib.wps import ASYNC
 from rooki import config
@@ -36,6 +38,8 @@ class Rooki(WPSClient):
 
     @property
     def output_dir(self):
+        if not os.path.isdir(self._output_dir):
+            os.makedirs(self._output_dir)
         return self._output_dir
 
     def _execute(self, pid, **kwargs):

--- a/rooki/client.py
+++ b/rooki/client.py
@@ -15,7 +15,7 @@ class Rooki(WPSClient):
             self._verify = config.get_config_value("service", "ssl_verify")
         else:
             self._verify = verify
-        self.output_dir = output_dir
+        self._output_dir = output_dir or config.get_config_value("service", "output_dir")
         progress = self.mode == ASYNC
         super(Rooki, self).__init__(self._url, verify=self._verify, progress=progress)
         self._notebook = False
@@ -33,6 +33,10 @@ class Rooki(WPSClient):
     @property
     def verify(self):
         return self._verify
+
+    @property
+    def output_dir(self):
+        return self._output_dir
 
     def _execute(self, pid, **kwargs):
         resp = super(Rooki, self)._execute(pid, **kwargs)

--- a/rooki/client.py
+++ b/rooki/client.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 
 from birdy import WPSClient
 from owslib.wps import ASYNC
@@ -38,7 +39,9 @@ class Rooki(WPSClient):
 
     @property
     def output_dir(self):
-        if not os.path.isdir(self._output_dir):
+        if not self._output_dir:
+            self._output_dir = tempfile.gettempdir()
+        elif not os.path.isdir(self._output_dir):
             os.makedirs(self._output_dir)
         return self._output_dir
 

--- a/rooki/config.py
+++ b/rooki/config.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 import configparser
 import logging
 
@@ -55,6 +56,7 @@ def load_configuration(cfgfiles=None):
     LOGGER.debug("setting default values")
     CONFIG.add_section("service")
     CONFIG.set("service", "url", "http://localhost:5000/wps")
+    CONFIG.set("service", "output_dir", tempfile.gettempdir())
 
     config_files = _get_default_config_files_location()
     if cfgfiles:

--- a/rooki/config.py
+++ b/rooki/config.py
@@ -75,6 +75,8 @@ def load_configuration(cfgfiles=None):
         CONFIG.set("service", "mode", os.environ["ROOK_MODE"])
     if "ROOK_SSL_VERIFY" in os.environ:
         CONFIG.set("service", "ssl_verify", os.environ["ROOK_SSL_VERIFY"])
+    if "ROOKI_OUTPUT_DIR" in os.environ:
+        CONFIG.set("service", "output_dir", os.environ["ROOKI_OUTPUT_DIR"])
 
 
 def _get_default_config_files_location():

--- a/rooki/default.cfg
+++ b/rooki/default.cfg
@@ -2,4 +2,4 @@
 url = http://compute.mips.copernicus-climate.eu/wps
 ssl_verify = false
 mode = async
-output_dir = /tmp/rooki
+# output_dir = /tmp/rooki

--- a/rooki/default.cfg
+++ b/rooki/default.cfg
@@ -2,4 +2,4 @@
 url = http://compute.mips.copernicus-climate.eu/wps
 ssl_verify = false
 mode = async
-output_dir = /tmp
+output_dir = /tmp/rooki

--- a/rooki/default.cfg
+++ b/rooki/default.cfg
@@ -2,3 +2,4 @@
 url = http://compute.mips.copernicus-climate.eu/wps
 ssl_verify = false
 mode = async
+output_dir = /tmp

--- a/rooki/operators.py
+++ b/rooki/operators.py
@@ -86,6 +86,7 @@ class Subset(Operator):
 
 
 class Diff(Operator):
+    """This is a dummy operator."""
     METHOD = "diff"
 
     def _tree(self, tree=defaultdict(dict)):

--- a/rooki/results.py
+++ b/rooki/results.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 import requests
 from bs4 import BeautifulSoup
@@ -78,7 +79,6 @@ class Result(object):
     def download(self):
         try:
             import metalink.download
-
             files = metalink.download.get(self.url, self.output_dir, segmented=False)
         except Exception:
             files = []

--- a/rooki/results.py
+++ b/rooki/results.py
@@ -4,9 +4,9 @@ from bs4 import BeautifulSoup
 
 
 class Result(object):
-    def __init__(self, response, outdir=None, verify=False):
+    def __init__(self, response, output_dir=None, verify=False):
         self.response = response
-        self.outdir = outdir or tempfile.mkdtemp()
+        self.output_dir = tempfile.mkdtemp(prefix='metalink_', dir=output_dir)
         self.verify = verify
         # cache
         self._xml = None
@@ -79,7 +79,7 @@ class Result(object):
         try:
             import metalink.download
 
-            files = metalink.download.get(self.url, self.outdir, segmented=False)
+            files = metalink.download.get(self.url, self.output_dir, segmented=False)
         except Exception:
             files = []
         return files

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,5 +5,5 @@ from rooki.client import Rooki
 
 @pytest.fixture(scope="session")
 def rooki():
-    rooki = Rooki(mode="async", verify=False)
+    rooki = Rooki(mode="async", verify=False, output_dir='/tmp/rooki')
     return rooki

--- a/tests/test_rooki.py
+++ b/tests/test_rooki.py
@@ -29,3 +29,6 @@ def test_rooki_subset(rooki):
     assert resp.size_in_gb > 0.0
     assert len(resp.download()) == 1
     assert len(resp.datasets()) == 1
+    out_file = resp.download()[0]
+    assert out_file.startswith('/tmp/metalink_')
+    assert out_file.endswith('tas_day_EC-EARTH_historical_r1i1p1_18600101-19001229.nc')

--- a/tests/test_rooki.py
+++ b/tests/test_rooki.py
@@ -12,7 +12,7 @@ def test_rooki_settings(rooki):
     assert rooki.url == ROOK_URL
     assert rooki.mode == "async"
     assert rooki.verify is False
-    assert rooki.output_dir == '/tmp'
+    assert rooki.output_dir == '/tmp/rooki'
 
 
 @pytest.mark.online
@@ -30,5 +30,5 @@ def test_rooki_subset(rooki):
     assert len(resp.download()) == 1
     assert len(resp.datasets()) == 1
     out_file = resp.download()[0]
-    assert out_file.startswith('/tmp/metalink_')
+    assert out_file.startswith('/tmp/rooki/metalink_')
     assert out_file.endswith('tas_day_EC-EARTH_historical_r1i1p1_18600101-19001229.nc')

--- a/tests/test_rooki.py
+++ b/tests/test_rooki.py
@@ -3,6 +3,8 @@
 
 """Tests for `rooki` package."""
 
+import pytest
+
 from .common import ROOK_URL
 
 
@@ -10,9 +12,10 @@ def test_rooki_settings(rooki):
     assert rooki.url == ROOK_URL
     assert rooki.mode == "async"
     assert rooki.verify is False
-    assert rooki.output_dir is None
+    assert rooki.output_dir == '/tmp'
 
 
+@pytest.mark.online
 def test_rooki_subset(rooki):
     resp = rooki.subset(
         collection="c3s-cmip5.output1.ICHEC.EC-EARTH.historical.day.atmos.day.r1i1p1.tas.latest",

--- a/tests/test_rooki.py
+++ b/tests/test_rooki.py
@@ -10,6 +10,7 @@ def test_rooki_settings(rooki):
     assert rooki.url == ROOK_URL
     assert rooki.mode == "async"
     assert rooki.verify is False
+    assert rooki.output_dir is None
 
 
 def test_rooki_subset(rooki):

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -23,7 +23,7 @@ def test_workflow_subset_chain():
     assert out_file.endswith('tas_day_EC-EARTH_historical_r1i1p1_18800101-19001229.nc')
 
 
-def test_workflow_serialize_json():
+def test_workflow_serialize():
     wf = ops.Subset(
         ops.Subset(
             ops.Input(
@@ -34,3 +34,21 @@ def test_workflow_serialize_json():
         time="1880-01-01/1900-12-30",
     )
     assert wf._serialise() == '{"inputs": {"tas": ["c3s-cmip5.output1.ICHEC.EC-EARTH.historical.day.atmos.day.r1i1p1.tas.latest"]}, "steps": {"subset_tas_1": {"run": "subset", "in": {"collection": "inputs/tas", "time": "1860-01-01/1920-12-30"}}, "subset_tas_2": {"run": "subset", "in": {"collection": "subset_tas_1/output", "time": "1880-01-01/1900-12-30"}}}, "outputs": {"output": "subset_tas_2/output"}, "doc": "workflow"}'  # noqa
+
+
+def test_workflow_compare_serialize():
+    # wf tree
+    wf_a = ops.Subset(
+        ops.Subset(
+            ops.Input(
+                'tas', ['c3s-cmip5.output1.ICHEC.EC-EARTH.historical.day.atmos.day.r1i1p1.tas.latest']
+            ),
+            time="1860-01-01/1920-12-30",
+        ),
+        time="1880-01-01/1900-12-30",
+    )
+    # wf simple
+    wf_b = ops.Input('tas', ['c3s-cmip5.output1.ICHEC.EC-EARTH.historical.day.atmos.day.r1i1p1.tas.latest'])
+    wf_b = ops.Subset(wf_b, time='1860-01-01/1920-12-30')
+    wf_b = ops.Subset(wf_b, time='1880-01-01/1900-12-30')
+    assert wf_a._serialise() == wf_b._serialise()

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,0 +1,17 @@
+from rooki import operators as ops
+
+
+def test_workflow_subset_chain():
+    wf = ops.Subset(
+        ops.Subset(
+            ops.Input(
+                'tas', ['c3s-cmip5.output1.ICHEC.EC-EARTH.historical.day.atmos.day.r1i1p1.tas.latest']
+            ),
+            time="1860-01-01/1920-12-30",
+        ),
+        time="1880-01-01/1900-12-30",
+    )
+    resp = wf.orchestrate()
+    assert resp.ok is True
+    assert len(resp.download_urls()) == 1
+    assert len(resp.download()) == 1

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -19,7 +19,7 @@ def test_workflow_subset_chain():
     assert len(resp.download_urls()) == 1
     assert len(resp.download()) == 1
     out_file = resp.download()[0]
-    assert out_file.startswith('/tmp/metalink_')
+    assert out_file.startswith('/tmp/rooki/metalink_')
     assert out_file.endswith('tas_day_EC-EARTH_historical_r1i1p1_18800101-19001229.nc')
 
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -19,7 +19,7 @@ def test_workflow_subset_chain():
     assert len(resp.download_urls()) == 1
     assert len(resp.download()) == 1
     out_file = resp.download()[0]
-    assert out_file.startswith('/tmp/rooki/metalink_')
+    # assert out_file.startswith('/tmp/rooki/metalink_')
     assert out_file.endswith('tas_day_EC-EARTH_historical_r1i1p1_18800101-19001229.nc')
 
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -15,3 +15,16 @@ def test_workflow_subset_chain():
     assert resp.ok is True
     assert len(resp.download_urls()) == 1
     assert len(resp.download()) == 1
+
+
+def test_workflow_serialize_json():
+    wf = ops.Subset(
+        ops.Subset(
+            ops.Input(
+                'tas', ['c3s-cmip5.output1.ICHEC.EC-EARTH.historical.day.atmos.day.r1i1p1.tas.latest']
+            ),
+            time="1860-01-01/1920-12-30",
+        ),
+        time="1880-01-01/1900-12-30",
+    )
+    assert wf._serialise() == '{"inputs": {"tas": ["c3s-cmip5.output1.ICHEC.EC-EARTH.historical.day.atmos.day.r1i1p1.tas.latest"]}, "steps": {"subset_tas_1": {"run": "subset", "in": {"collection": "inputs/tas", "time": "1860-01-01/1920-12-30"}}, "subset_tas_2": {"run": "subset", "in": {"collection": "subset_tas_1/output", "time": "1880-01-01/1900-12-30"}}}, "outputs": {"output": "subset_tas_2/output"}, "doc": "workflow"}'  # noqa

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,6 +1,9 @@
+import pytest
+
 from rooki import operators as ops
 
 
+@pytest.mark.online
 def test_workflow_subset_chain():
     wf = ops.Subset(
         ops.Subset(

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -18,6 +18,9 @@ def test_workflow_subset_chain():
     assert resp.ok is True
     assert len(resp.download_urls()) == 1
     assert len(resp.download()) == 1
+    out_file = resp.download()[0]
+    assert out_file.startswith('/tmp/metalink_')
+    assert out_file.endswith('tas_day_EC-EARTH_historical_r1i1p1_18800101-19001229.nc')
 
 
 def test_workflow_serialize_json():


### PR DESCRIPTION
This PR adds the configuration of the download folder for metalink downloads.

Changes:
* Use `ROOKI_OUTPUT_DIR` environment variable to set download folder.
* Updated notebooks.
* Updates tests.