### PR TITLE
added a quick fix for missing cancel

### DIFF
--- a/rooki/client.py
+++ b/rooki/client.py
@@ -27,6 +27,10 @@ class Rooki(WPSClient):
         self.logger = logging.getLogger("rooki")
         self.logger.addHandler(logging.NullHandler())
 
+    def cancel(self):
+        # https://github.com/roocs/rook/issues/143
+        self.logger.warn("cancel was called but is not available.")
+
     @property
     def url(self):
         return self._url


### PR DESCRIPTION
This PR is a quick-fix for the missing `cancel` function in birdy.

See the following issue:
https://github.com/roocs/rook/issues/143