### PR TITLE
update usage nb: added geoip and ghc

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  # - pip
+  - pip
   #- openssl
   - birdy
   - beautifulsoup4
@@ -27,5 +27,5 @@ dependencies:
   # tests
   #- pytest
   #- flake8
-  #- pip:
-  #  - -e git+https://github.com/metalink-dev/pymetalink.git@master#egg=metalink
+  - pip:
+    - geoip2nation

--- a/notebooks/demo/rook-usage.ipynb
+++ b/notebooks/demo/rook-usage.ipynb
@@ -8,7 +8,8 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "os.environ['ROOK_URL'] = 'http://rook.dkrz.de/wps'"
+    "#os.environ['ROOK_URL'] = 'http://rook.dkrz.de/wps'\n",
+    "os.environ['ROOK_URL'] = 'http://rook3.cloud.dkrz.de/wps'"
    ]
   },
   {
@@ -36,7 +37,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "resp = rooki.usage(time='2021-03-23/2021-04-30')"
+    "resp = rooki.usage(time='2021-03-01/2021-05-30')"
    ]
   },
   {
@@ -418,6 +419,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "ae5ee8d7-e1ec-490b-9b1f-93d839da88d5",
+   "metadata": {},
+   "source": [
+    "### Downloads size"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "dec46445-88c0-4663-8107-5bd352834348",
@@ -425,6 +434,75 @@
    "outputs": [],
    "source": [
     "df_downloads['size'].sum() / 1024 ** 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60631108-addb-4a51-a920-d690d1591b7a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def size_mb(size):\n",
+    "    return size / 1024 ** 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6b5ec0b1-0d5d-4f04-a3a6-102ed9f0bb45",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_downloads['size_mb'] = df_downloads['size'].apply(size_mb)\n",
+    "df_downloads"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "50baabf8-4b02-487f-9230-79c2d4091496",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_downloads.hvplot.hist(y='size_mb')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5a88f29-150a-401a-8352-2c98a5fcd926",
+   "metadata": {},
+   "source": [
+    "### Download size per day"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3d8be35b-0958-45dd-8d62-e813b6df2de7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "downloads_per_day = df_downloads.groupby(df_downloads.datetime.dt.date)[\"size_mb\"].sum()\n",
+    "downloads_per_day"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d41436a9-2e4f-44cd-a24e-3b4a9c588f05",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "downloads_per_day.hvplot.bar()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae3a8490-9c6f-404d-be0d-3ce1b3fca792",
+   "metadata": {},
+   "source": [
+    "### Download requests per day"
    ]
   },
   {
@@ -442,7 +520,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c8df63e3-1dc0-4406-af11-33376bf5be6f",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "df_downloads.hvplot.hist(y='datetime', bins=days)"
@@ -453,7 +533,7 @@
    "id": "05c88c8b-05f5-41e0-8110-9a04810d1c72",
    "metadata": {},
    "source": [
-    "## Downloads by IP address"
+    "### Downloads by IP address"
    ]
   },
   {
@@ -464,6 +544,109 @@
    "outputs": [],
    "source": [
     "df_downloads.remote_host_ip.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1837426-c3ec-4ddc-9132-be7da03deb34",
+   "metadata": {},
+   "source": [
+    "### Downloads GeoIP\n",
+    "https://pypi.org/project/geoip2nation/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0a710753-9445-481f-bcd5-456ca9a2bb70",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from geoip import xgeoip\n",
+    "r = xgeoip.GeoIp()\n",
+    "r.load_memory()\n",
+    "\n",
+    "def lookup_ip(ip):\n",
+    "    return r.resolve(ip).country"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b016a320-344e-41cf-b79b-7eb947054161",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_downloads['geoip'] = df_downloads.remote_host_ip.apply(lookup_ip)\n",
+    "df_downloads"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37cf67f8-ce17-4ade-9b51-f074794f1c9c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_downloads.geoip.value_counts().hvplot.bar()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a8228e3b-60e9-4e94-aee9-1669cd5551f9",
+   "metadata": {},
+   "source": [
+    "## GeoHealthCheck\n",
+    "https://geohealthcheck.cloud.dkrz.de"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6b925133-33a6-465c-bb13-116eb395a541",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "from io import StringIO\n",
+    "ghc_url = \"https://geohealthcheck.cloud.dkrz.de/resource/45/history/csv\"\n",
+    "req = requests.get(ghc_url, verify=False)\n",
+    "df_ghc = pd.read_csv(StringIO(req.text), parse_dates=['checked_datetime'])\n",
+    "df_ghc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6ce9a10c-4a59-47d1-9572-3bad785400d9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_ghc.status.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0793b73b-f320-4dfe-9ed4-44276db2dc63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def up(status):\n",
+    "    if status == True:\n",
+    "        return 1\n",
+    "    return 0\n",
+    "df_ghc['up'] = df_ghc.status.apply(up)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "50c9dc88-a94f-4237-b378-411f72b1a40a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_ghc.hvplot.line(x='checked_datetime', y='up')"
    ]
   }
  ],


### PR DESCRIPTION
This PR updates the rook usage notebook with an example for GeoIP and GeoHealthCheck.