### PR TITLE
update intake notesbooks

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,6 +19,8 @@ dependencies:
   # intake catalog
   - intake
   - pandas
+  - dask
+  - fsspec
   - requests
   - aiohttp
   # vis

--- a/notebooks/demo/demo-intake-catalog.ipynb
+++ b/notebooks/demo/demo-intake-catalog.ipynb
@@ -36,7 +36,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cat_url = \"https://raw.githubusercontent.com/cp4cds/c3s_34g_manifests/update_intake_catalog/intake/catalogs/c3s.yaml\"\n",
+    "# cat_url = \"https://raw.githubusercontent.com/cp4cds/c3s_34g_manifests/master/intake/catalogs/c3s.yaml\"\n",
+    "cat_url = \"https://github.com/cehbrecht/c3s_34g_manifests/raw/fix-intake-catalog/intake/catalogs/c3s.yaml\"\n",
     "cat = intake.open_catalog(cat_url)\n"
    ]
   },
@@ -271,7 +272,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -285,7 +286,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/notebooks/demo/demo-intake-ecmwf.ipynb
+++ b/notebooks/demo/demo-intake-ecmwf.ipynb
@@ -35,7 +35,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url = \"https://raw.githubusercontent.com/cp4cds/c3s_34g_manifests/update_intake_catalog/intake/catalogs/c3s.yaml\""
+    "# cat_url = \"https://raw.githubusercontent.com/cp4cds/c3s_34g_manifests/master/intake/catalogs/c3s.yaml\"\n",
+    "cat_url = \"https://github.com/cehbrecht/c3s_34g_manifests/raw/fix-intake-catalog/intake/catalogs/c3s.yaml\""
    ]
   },
   {
@@ -45,7 +46,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cat = intake.open_catalog(url)"
+    "cat = intake.open_catalog(cat_url)"
    ]
   },
   {
@@ -272,7 +273,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -286,7 +287,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -29,6 +29,7 @@ WF_EXAMPLE = {
 
 
 @pytest.mark.online
+@pytest.mark.xfail(reason="online wps not always available")
 def test_workflow_subset_chain():
     wf = ops.Subset(
         ops.Subset(


### PR DESCRIPTION
This PR updates the intake notebooks. It is using an updated catalog to avoid issues with latest `dask` and `fsspec` libraries. 