### PR TITLE
Fix workflow tree init issue

### DIFF
--- a/notebooks/errors/cds-error-2026-06-30-workflow-tree-reuse.ipynb
+++ b/notebooks/errors/cds-error-2026-06-30-workflow-tree-reuse.ipynb
@@ -1,0 +1,245 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "db86af35",
+   "metadata": {},
+   "source": [
+    "# Issue with Rooki workflow serialization tree reuse\n",
+    "\n",
+    "This notebook documents a fixed workflow serialization issue reported by a user. The problem was caused by mutable default arguments in `Input._tree()` and `Operator._tree()`: separate calls to `_serialise()` could reuse the same workflow tree and accidentally carry previous `inputs` and `steps` into a later request.\n",
+    "\n",
+    "The example below builds two independent workflows in the same Python process. The second workflow should contain only `tas`, not the earlier `huss` request."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a95d3418",
+   "metadata": {},
+   "source": [
+    "## Imports\n",
+    "\n",
+    "The notebook serializes workflows to show the fixed client-side behavior. Importing `rooki.operators` initializes the Rooki WPS client and may contact the configured service, for example `rook.dkrz.de`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "97dfe6e2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T13:04:03.220951Z",
+     "iopub.status.busy": "2026-07-01T13:04:03.220616Z",
+     "iopub.status.idle": "2026-07-01T13:04:03.752929Z",
+     "shell.execute_reply": "2026-07-01T13:04:03.751983Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from pprint import pprint\n",
+    "\n",
+    "from rooki import operators as rookops"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72f49dbd",
+   "metadata": {},
+   "source": [
+    "## First workflow"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "4b1e1e16",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T13:04:03.756331Z",
+     "iopub.status.busy": "2026-07-01T13:04:03.756094Z",
+     "iopub.status.idle": "2026-07-01T13:04:03.760306Z",
+     "shell.execute_reply": "2026-07-01T13:04:03.759595Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'doc': 'workflow',\n",
+      " 'inputs': {'huss': ['c3s-cordex.example.huss']},\n",
+      " 'outputs': {'output': 'subset_huss_1/output'},\n",
+      " 'steps': {'subset_huss_1': {'in': {'collection': 'inputs/huss',\n",
+      "                                    'time': '2006/2006',\n",
+      "                                    'time_components': 'month:jan|year:2006'},\n",
+      "                             'run': 'subset'}}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "workflow_huss = rookops.Subset(\n",
+    "    rookops.Input(\"huss\", [\"c3s-cordex.example.huss\"]),\n",
+    "    time=\"2006/2006\",\n",
+    "    time_components=\"month:jan|year:2006\",\n",
+    ")\n",
+    "\n",
+    "doc_huss = json.loads(workflow_huss._serialise())\n",
+    "pprint(doc_huss)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1546d392",
+   "metadata": {},
+   "source": [
+    "## Second workflow in the same process"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "83e37a31",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T13:04:03.762999Z",
+     "iopub.status.busy": "2026-07-01T13:04:03.762734Z",
+     "iopub.status.idle": "2026-07-01T13:04:03.766828Z",
+     "shell.execute_reply": "2026-07-01T13:04:03.766133Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'doc': 'workflow',\n",
+      " 'inputs': {'tas': ['c3s-cordex.example.tas']},\n",
+      " 'outputs': {'output': 'subset_tas_1/output'},\n",
+      " 'steps': {'subset_tas_1': {'in': {'collection': 'inputs/tas',\n",
+      "                                   'time': '2007/2007',\n",
+      "                                   'time_components': 'month:feb|year:2007'},\n",
+      "                            'run': 'subset'}}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "workflow_tas = rookops.Subset(\n",
+    "    rookops.Input(\"tas\", [\"c3s-cordex.example.tas\"]),\n",
+    "    time=\"2007/2007\",\n",
+    "    time_components=\"month:feb|year:2007\",\n",
+    ")\n",
+    "\n",
+    "doc_tas = json.loads(workflow_tas._serialise())\n",
+    "pprint(doc_tas)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "209802c0",
+   "metadata": {},
+   "source": [
+    "## Check the fixed behavior\n",
+    "\n",
+    "The second serialized workflow must be isolated from the first one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "24dc1019",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T13:04:03.769041Z",
+     "iopub.status.busy": "2026-07-01T13:04:03.768905Z",
+     "iopub.status.idle": "2026-07-01T13:04:03.772066Z",
+     "shell.execute_reply": "2026-07-01T13:04:03.771502Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OK: each _serialise() call uses a fresh workflow tree.\n"
+     ]
+    }
+   ],
+   "source": [
+    "assert set(doc_huss[\"inputs\"]) == {\"huss\"}\n",
+    "assert set(doc_huss[\"steps\"]) == {\"subset_huss_1\"}\n",
+    "\n",
+    "assert set(doc_tas[\"inputs\"]) == {\"tas\"}\n",
+    "assert set(doc_tas[\"steps\"]) == {\"subset_tas_1\"}\n",
+    "assert \"huss\" not in doc_tas[\"inputs\"]\n",
+    "assert \"subset_huss_1\" not in doc_tas[\"steps\"]\n",
+    "\n",
+    "print(\"OK: each _serialise() call uses a fresh workflow tree.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26879d3a",
+   "metadata": {},
+   "source": [
+    "## Input-only serialization\n",
+    "\n",
+    "The same isolation also applies when serializing bare `Input` objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "fde2f73f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T13:04:03.773777Z",
+     "iopub.status.busy": "2026-07-01T13:04:03.773608Z",
+     "iopub.status.idle": "2026-07-01T13:04:03.776482Z",
+     "shell.execute_reply": "2026-07-01T13:04:03.775988Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'doc': 'workflow', 'inputs': {'huss': ['c3s-cordex.example.huss']}}\n",
+      "{'doc': 'workflow', 'inputs': {'tas': ['c3s-cordex.example.tas']}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "input_huss = json.loads(rookops.Input(\"huss\", [\"c3s-cordex.example.huss\"])._serialise())\n",
+    "input_tas = json.loads(rookops.Input(\"tas\", [\"c3s-cordex.example.tas\"])._serialise())\n",
+    "\n",
+    "assert input_huss[\"inputs\"] == {\"huss\": [\"c3s-cordex.example.huss\"]}\n",
+    "assert input_tas[\"inputs\"] == {\"tas\": [\"c3s-cordex.example.tas\"]}\n",
+    "\n",
+    "pprint(input_huss)\n",
+    "pprint(input_tas)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/rooki/operators.py
+++ b/rooki/operators.py
@@ -18,7 +18,8 @@ class Operator:
         self.args = args
         self.kwargs = kwargs
 
-    def _tree(self, tree=defaultdict(dict)):
+    def _tree(self, tree=None):
+        tree = _init_tree(tree)
         # args = [arg._tree(tree) for arg in self.args]
         [arg._tree(tree) for arg in self.args]
         tree["steps"][self.method_key] = {
@@ -74,7 +75,8 @@ class Input:
         reinit()
         return rooki.orchestrate(workflow=self._serialise())
 
-    def _tree(self, tree=defaultdict(dict)):
+    def _tree(self, tree=None):
+        tree = _init_tree(tree)
         tree["inputs"][self.variable] = self.dataset
         return tree
 
@@ -115,7 +117,8 @@ class Diff(Operator):
 
     METHOD = "diff"
 
-    def _tree(self, tree=defaultdict(dict)):
+    def _tree(self, tree=None):
+        tree = _init_tree(tree)
         # args = [arg._tree(tree) for arg in self.args]
         [arg._tree(tree) for arg in self.args]
         tree["steps"][self.method_key] = {
@@ -140,3 +143,7 @@ def _unpack_if_single(list):
     except ValueError:
         item = list
     return item
+
+
+def _init_tree(tree):
+    return tree if tree is not None else defaultdict(dict)

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,4 +22,8 @@ exclude = docs
 test = pytest
 
 [tool:pytest]
-collect_ignore = ['setup.py']
+markers =
+    online: marks tests that require an online WPS service
+    slow: marks tests as slow
+filterwarnings =
+    ignore:The use of "username", "password", "verify", and "cert" is deprecated.*:DeprecationWarning:owslib.wps

--- a/tests/test_rooki.py
+++ b/tests/test_rooki.py
@@ -17,7 +17,7 @@ def test_rooki_settings(rooki):
 
 
 @pytest.mark.online
-#@pytest.mark.xfail(reason="fails on GitHub CI ... works locally")
+# @pytest.mark.xfail(reason="fails on GitHub CI ... works locally")
 @pytest.mark.skip(reason="needs to be fixed")
 def test_rooki_subset(rooki):
     resp = rooki.subset(
@@ -53,7 +53,7 @@ def test_rooki_errors_not_avail_op(rooki):
 
 
 @pytest.mark.online
-#@pytest.mark.xfail(reason="XFAIL at service provider site, otherwise XPASS")
+# @pytest.mark.xfail(reason="XFAIL at service provider site, otherwise XPASS")
 @pytest.mark.skip(reason="needs to be fixed")
 def test_rooki_errors_access_denied():
     from rooki.client import Rooki

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -93,3 +93,55 @@ def test_workflow_compare_serialize():
     wf_b = ops.Subset(wf_b, time="1860-01-01/1920-12-30")
     wf_b = ops.Subset(wf_b, time="1880-01-01/1900-12-30")
     assert wf_a._serialise() == wf_b._serialise()
+
+
+def test_input_serialize_does_not_reuse_previous_tree():
+    wf_a = ops.Input("huss", ["c3s-cordex.huss"])
+    wf_b = ops.Input("tas", ["c3s-cordex.tas"])
+
+    assert json.loads(wf_a._serialise())["inputs"] == {"huss": ["c3s-cordex.huss"]}
+    assert json.loads(wf_b._serialise())["inputs"] == {"tas": ["c3s-cordex.tas"]}
+
+
+def test_workflow_serialize_does_not_reuse_previous_tree():
+    wf_a = ops.Subset(
+        ops.Input("huss", ["c3s-cordex.huss"]),
+        time="2006/2006",
+        time_components="month:jan|year:2006",
+    )
+    wf_b = ops.Subset(
+        ops.Input("tas", ["c3s-cordex.tas"]),
+        time="2007/2007",
+        time_components="month:feb|year:2007",
+    )
+
+    assert json.loads(wf_a._serialise()) == {
+        "inputs": {"huss": ["c3s-cordex.huss"]},
+        "steps": {
+            "subset_huss_1": {
+                "run": "subset",
+                "in": {
+                    "collection": "inputs/huss",
+                    "time": "2006/2006",
+                    "time_components": "month:jan|year:2006",
+                },
+            }
+        },
+        "outputs": {"output": "subset_huss_1/output"},
+        "doc": "workflow",
+    }
+    assert json.loads(wf_b._serialise()) == {
+        "inputs": {"tas": ["c3s-cordex.tas"]},
+        "steps": {
+            "subset_tas_1": {
+                "run": "subset",
+                "in": {
+                    "collection": "inputs/tas",
+                    "time": "2007/2007",
+                    "time_components": "month:feb|year:2007",
+                },
+            }
+        },
+        "outputs": {"output": "subset_tas_1/output"},
+        "doc": "workflow",
+    }

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -29,7 +29,7 @@ WF_EXAMPLE = {
 
 
 @pytest.mark.online
-#@pytest.mark.xfail(reason="online wps not always available")
+# @pytest.mark.xfail(reason="online wps not always available")
 @pytest.mark.skip(reason="needs to be fixed")
 def test_workflow_subset_chain():
     wf = ops.Subset(


### PR DESCRIPTION
This PR fixes the workflow tree init issue. When run 2 or more workflow/orchestrate operations the tree accumulated previous parameters.